### PR TITLE
:bug: Correction d'une commande Docker dans le chapitre "Nos fichiers dans les images"

### DIFF
--- a/content/chapitres/fichiers-nommage-inspect.adoc
+++ b/content/chapitres/fichiers-nommage-inspect.adoc
@@ -914,7 +914,7 @@ image::fichiers-output67_with_transparency.png[height=500]
 [%step]
 [source,bash]
 ----
-docker container inspect –format '--format '{{.NetworkSettings.IPAddress}}' <ContainerID>
+docker container inspect --format "{{.NetworkSettings.IPAddress}}" <ContainerID>
 ----
 
 [.notes]


### PR DESCRIPTION
La commande pour récupérer la valeur de `IPAdress` en lançant `docker container inspect` a été corrigée et fonctionne désormais.