### PR TITLE
fix: enable livereload and minor toolchain improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,9 +38,7 @@ services:
       -t png -o /app/content/media/qrcode.png ${PRESENTATION_URL}
 
   pdf:
-    image: ghcr.io/astefanutti/decktape:3.7.0
-    # build:
-    #   context: ./dockerfiles/pdf
+    image: ghcr.io/astefanutti/decktape:3.14.0
     depends_on:
       build:
         condition: service_completed_successfully # PDF is generated from the dist/index.html

--- a/gulp/gulpfile.js
+++ b/gulp/gulpfile.js
@@ -26,43 +26,51 @@ var current_config = {
 
 function prepare_revealjs() {
     return src(current_config.nodeModulesDir + '/reveal.js/dist/**/*')
-        .pipe(dest(current_config.buildDir + '/reveal.js/dist/'));
+        .pipe(dest(current_config.buildDir + '/reveal.js/dist/'))
+        .pipe(browserSync.stream());;
 }
 
 function prepare_revealjs_core_plugins() {
-    return src(current_config.nodeModulesDir + '/reveal.js/plugin/**/*')
-        .pipe(dest(current_config.buildDir + '/reveal.js/plugin/'));
+    return src(current_config.nodeModulesDir + '/reveal.js/plugin/**/*', { encoding: false })
+        .pipe(dest(current_config.buildDir + '/reveal.js/plugin/'))
+        .pipe(browserSync.stream());
 }
 
 function prepare_revealjs_external_plugins() {
-    return src(current_config.nodeModulesDir + '/reveal.js-plugins/**/*')
-        .pipe(dest(current_config.buildDir + '/reveal.js/reveal.js-plugins/'));
+    return src(current_config.nodeModulesDir + '/reveal.js-plugins/**/*', { encoding: false })
+        .pipe(dest(current_config.buildDir + '/reveal.js/reveal.js-plugins/'))
+        .pipe(browserSync.stream());
 }
 
 function prepare_revealjs_menu_plugin() {
-    return src(current_config.nodeModulesDir + '/reveal.js-menu/**/*')
-        .pipe(dest(current_config.buildDir + '/reveal.js/reveal.js-plugins/menu/'));
+    return src(current_config.nodeModulesDir + '/reveal.js-menu/**/*', { encoding: false })
+        .pipe(dest(current_config.buildDir + '/reveal.js/reveal.js-plugins/menu/'))
+        .pipe(browserSync.stream());
 }
 
 function prepare_plugin_copycode() {
-    return src(current_config.nodeModulesDir + '/reveal.js-copycode/plugin/copycode/**/*')
-        .pipe(dest(current_config.buildDir + '/reveal.js/plugin/reveal.js-copycode/'));
+    return src(current_config.nodeModulesDir + '/reveal.js-copycode/plugin/copycode/**/*', { encoding: false })
+        .pipe(dest(current_config.buildDir + '/reveal.js/plugin/reveal.js-copycode/'))
+        .pipe(browserSync.stream());
 }
 
 function prepare_highlightjs_min() {
     return src(current_config.nodeModulesDir + '/@highlightjs/cdn-assets/highlight.min.js')
-        .pipe(dest(current_config.buildDir + '/highlightjs/'));
+        .pipe(dest(current_config.buildDir + '/highlightjs/'))
+        .pipe(browserSync.stream());
 }
 
 function prepare_highlightjs_languages() {
     return src(current_config.nodeModulesDir + '/@highlightjs/cdn-assets/languages**/*')
-        .pipe(dest(current_config.buildDir + '/highlightjs/'));
+        .pipe(dest(current_config.buildDir + '/highlightjs/'))
+        .pipe(browserSync.stream());
 }
 
 
 function prepare_plugin_clipboardjs() {
-    return src(current_config.nodeModulesDir + '/clipboard/dist/clipboard.min.js')
-        .pipe(dest(current_config.buildDir + '/scripts/'));
+    return src(current_config.nodeModulesDir + '/clipboard/dist/clipboard.min.js', { encoding: false })
+        .pipe(dest(current_config.buildDir + '/scripts/'))
+        .pipe(browserSync.stream());
 }
 
 function styles() {
@@ -70,7 +78,8 @@ function styles() {
         .pipe(sass().on('error', sass.logError))
         .pipe(rename('build.css'))
         .pipe(csso())
-        .pipe(dest(current_config.buildDir + '/styles/'));
+        .pipe(dest(current_config.buildDir + '/styles/'))
+        .pipe(browserSync.stream());
 }
 
 function html() {
@@ -94,12 +103,14 @@ function html() {
 
 function media() {
     return src(current_config.mediaSrcPath + '/*', { encoding: false })
-        .pipe(dest(current_config.buildDir + '/media/'));
+        .pipe(dest(current_config.buildDir + '/media/'))
+        .pipe(browserSync.stream());
 }
 
 function favicon() {
-    return src(current_config.faviconPath)
-        .pipe(dest(current_config.buildDir + '/'));
+    return src(current_config.faviconPath, { encoding: false })
+        .pipe(dest(current_config.buildDir + '/'))
+        .pipe(browserSync.stream());
 }
 
 function serve(cb) {
@@ -132,7 +143,7 @@ const watchFiles = function () {
         current_config.stylesSrcPath + '/**/*.scss',
     ], series(styles));
 
-    watch("./*.html").on('change', browserSync.reload);
+    watch(current_config.buildDir + '/*.html').on('change', browserSync.reload);
 }
 
 function clean() {

--- a/gulp/gulpfile.js
+++ b/gulp/gulpfile.js
@@ -2,12 +2,12 @@
 
 const { series, parallel, src, dest, watch } = require('gulp');
 const { exec } = require('child_process');
-var rename = require("gulp-rename");
-var browserSync = require('browser-sync').create();
+const rename = require("gulp-rename");
+const browserSync = require('browser-sync').create();
 const sass = require('gulp-sass')(require('sass'));
 const csso = require('gulp-csso');
-var asciidoctor = require('@asciidoctor/core')();
-var asciidoctorRevealjs = require('@asciidoctor/reveal.js');
+const asciidoctor = require('@asciidoctor/core')();
+const asciidoctorRevealjs = require('@asciidoctor/reveal.js');
 
 asciidoctorRevealjs.register();
 
@@ -82,23 +82,21 @@ function styles() {
         .pipe(browserSync.stream());
 }
 
-function html() {
-    return src(current_config.sourcesDir + '/**/*.adoc', { read: false })
-        .on('end', function () {
-            asciidoctor.convertFile(
-                current_config.sourcesDir + '/index.adoc',
-                {
-                    safe: 'unsafe',
-                    backend: 'revealjs',
-                    attributes: {
-                        'revealjsdir': 'node_modules/reveal.js@',
-                        'presentationUrl': process.env.PRESENTATION_URL,
-                        'repositoryUrl': process.env.REPOSITORY_URL,
-                    },
-                    to_dir: current_config.buildDir,
-                }
-            );
-        });
+function html(cb) {
+    asciidoctor.convertFile(
+        current_config.sourcesDir + '/index.adoc',
+        {
+            safe: 'unsafe',
+            backend: 'revealjs',
+            attributes: {
+                'revealjsdir': 'node_modules/reveal.js@',
+                'presentationUrl': process.env.PRESENTATION_URL,
+                'repositoryUrl': process.env.REPOSITORY_URL,
+            },
+            to_dir: current_config.buildDir,
+        }
+    );
+    cb();
 }
 
 function media() {
@@ -169,4 +167,4 @@ const build = series(
 );
 
 exports.build = build;
-exports.default = series(clean, serve, build, watchFiles)
+exports.default = series(clean, build, serve, watchFiles)

--- a/npm-packages/package-lock.json
+++ b/npm-packages/package-lock.json
@@ -10,8 +10,8 @@
             "devDependencies": {
                 "@asciidoctor/reveal.js": "5.1.0",
                 "@highlightjs/cdn-assets": "11.10.0",
-                "asciidoctor": "^3.0.4",
-                "browser-sync": "^3.0.3",
+                "asciidoctor": "3.0.4",
+                "browser-sync": "3.0.3",
                 "clipboard": "2.0.11",
                 "gulp": "5.0.0",
                 "gulp-autoprefixer": "9.0.0",
@@ -24,7 +24,7 @@
                 "reveal.js-copycode": "1.2.0",
                 "reveal.js-menu": "2.1.0",
                 "reveal.js-plugins": "4.2.5",
-                "sass": "^1.80.5"
+                "sass": "1.80.5"
             }
         },
         "../usr/local/lib/node_modules/gulp": {

--- a/npm-packages/package.json
+++ b/npm-packages/package.json
@@ -5,8 +5,8 @@
     "repository": "https://github.com/gounthar/cours-devops-docker",
     "devDependencies": {
         "@asciidoctor/reveal.js": "5.1.0",
-        "asciidoctor": "^3.0.4",
-        "browser-sync": "^3.0.3",
+        "asciidoctor": "3.0.4",
+        "browser-sync": "3.0.3",
         "clipboard": "2.0.11",
         "gulp": "5.0.0",
         "gulp-autoprefixer": "9.0.0",
@@ -20,6 +20,6 @@
         "reveal.js-plugins": "4.2.5",
         "reveal.js-menu": "2.1.0",
         "@highlightjs/cdn-assets": "11.10.0",
-        "sass": "^1.80.5"
+        "sass": "1.80.5"
     }
 }


### PR DESCRIPTION
The livereload for local developement was broken by #159.
I discovered it on my own course so here is the PR which fixes it.

It comes along with a few toolchain chores:

- Bump decktape image (for PDF generation) to latest version (better arm64 support, bugfixes, faster)
- Remove NPM version carrets to avoid bad surprises in the future (one of the root causes which led to #159)
- Applied a few feedbacks from coderabbitai (nice tool!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced build process with live reloading capabilities for improved development workflow.
  
- **Bug Fixes**
	- Updated the PDF service image version for better stability and performance.

- **Chores**
	- Locked specific dependency versions to ensure consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->