### PR TITLE
Fix URL

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -13,8 +13,8 @@ on:
   workflow_dispatch:
 
 env:
-  REPOSITORY_URL: https://github.com/${{ github.repository_owner }}/${{ github.repository }}
-  PRESENTATION_URL: https://${{ github.repository_owner }}.github.io/${{ github.repository }}/${{ github.ref_name }}
+  REPOSITORY_URL: https://github.com/${{ github.repository }}
+  PRESENTATION_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ github.ref_name }}
 
 jobs:
   build-slides:


### PR DESCRIPTION
Link to the a fixed website [https://arnaud158.github.io/cours-devops-docker/main/#/](https://arnaud158.github.io/cours-devops-docker/main/#/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected the generated presentation URL to point to the correct repository path, preventing broken links on published pages.

- Chores
  - Updated build configuration environment variables to remove duplicated owner segments in URLs.
  - No changes to build steps or behavior; only URL values were adjusted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->