### PR TITLE
feat: add Ubuntu 25.04 Podman/Docker conflict resolution

### DIFF
--- a/content/chapitres/dev-env.adoc
+++ b/content/chapitres/dev-env.adoc
@@ -134,11 +134,13 @@ Bref, on ne l'a pas ici. `¯\_(ツ)_/¯`
 --
 [.column]
 --
-==== Solution 1 : Variable DOCKER_HOST (rapide)
+.Solution 1 : Variable DOCKER_HOST (rapide)
 
 **Pour une session :**
 [source,bash]
 ----
+# Vérifier que le service Docker tourne :
+systemctl is-active --quiet docker || echo "⚠️ Docker n'est pas démarré (voir Solution 2)"
 export DOCKER_HOST=unix:///var/run/docker.sock
 docker ps  # Devrait fonctionner
 ----
@@ -146,26 +148,33 @@ docker ps  # Devrait fonctionner
 **Permanent (ajouter à ~/.bashrc ou ~/.zshrc) :**
 [source,bash]
 ----
-echo 'export DOCKER_HOST=unix:///var/run/docker.sock' >> ~/.bashrc
-source ~/.bashrc
+echo 'export DOCKER_HOST=unix:///var/run/docker.sock' >> ~/.bashrc && source ~/.bashrc
+# ou pour zsh :
+echo 'export DOCKER_HOST=unix:///var/run/docker.sock' >> ~/.zshrc && source ~/.zshrc
 ----
 --
 [.column]
 --
-==== Solution 2 : Désinstaller Podman (recommandé)
+.Solution 2 : Désinstaller Podman (recommandé)
 
 **Si vous n'utilisez pas Podman :**
 [source,bash]
 ----
 sudo apt remove podman podman-docker
 sudo apt install docker.io
-sudo systemctl start docker
-sudo systemctl enable docker
+sudo systemctl enable --now docker
 # Ajouter l'utilisateur au groupe docker
 sudo usermod -aG docker $USER
+# (optionnel mais utile pour le cours)
+sudo apt install -y docker-compose-plugin
+newgrp docker <<'EOF'
+docker ps
+EOF
 ----
 
 **⚠️ Attention :** Après `usermod`, vous devez fermer votre session (logout/login) ou redémarrer votre shell pour que le changement de groupe prenne effet.
+
+**Astuce :** Utilisez `newgrp docker` pour activer le groupe sans vous déconnecter.
 
 **Alternative :** Préfixer chaque commande avec `sudo` (ex: `sudo docker ps`) si vous ne voulez pas rejoindre le groupe.
 --
@@ -184,7 +193,7 @@ Ubuntu 25.04 (Noble Numbat) marque un changement majeur : Podman devient le mote
 - Plus sécurisé par défaut (rootless)
 
 **Le conflit :**
-- Podman crée un socket `/run/podman/podman.sock`
+- Podman crée un socket `/run/podman/podman.sock` (ou rootless: `/run/user/$UID/podman/podman.sock`)
 - Docker cherche `/var/run/docker.sock`
 - Si les deux sont installés : confusion entre les sockets
 


### PR DESCRIPTION
## Summary

Ajoute une section dédiée pour résoudre le conflit Podman/Docker sur Ubuntu 25.04+.

## Problème

Ubuntu 25.04 (Noble Numbat) est livré avec **Podman par défaut** à la place de Docker, ce qui peut empêcher Docker de fonctionner correctement avec l'erreur classique :
```
Cannot connect to the Docker daemon
```

## Solutions proposées

### 🚀 Solution 1 : Variable DOCKER_HOST (rapide)

**Temporaire :**
```bash
export DOCKER_HOST=unix:///var/run/docker.sock
```

**Permanent :**
```bash
echo 'export DOCKER_HOST=unix:///var/run/docker.sock' >> ~/.bashrc
source ~/.bashrc
```

✅ Rapide, non-destructif
✅ Garde Podman installé
❌ Doit être configuré par utilisateur
❌ Peut causer confusion si oublié

### 🎯 Solution 2 : Désinstaller Podman (recommandé)

```bash
sudo apt remove podman podman-docker
sudo apt install docker.io
sudo systemctl start docker
sudo systemctl enable docker
```

✅ Solution propre et définitive
✅ Pas de configuration supplémentaire
✅ Recommandé pour un cours Docker
❌ Supprime Podman

## Contenu ajouté

**Slides étudiants :**
- Explication du problème (Ubuntu 25.04 + Podman)
- 2 solutions claires avec exemples de commandes
- Symptôme typique

**Notes speaker :**
- Contexte du changement (pourquoi Podman par défaut)
- Explications techniques (sockets, daemonless, etc.)
- Avantages/inconvénients de chaque solution
- Recommandations pour le TP
- Alternative bonus : utiliser Podman avec `alias docker=podman`

## Contexte technique

**Pourquoi ce changement Ubuntu ?**
- Podman est "daemonless" (pas de daemon root)
- Mieux intégré avec systemd
- Plus sécurisé par défaut (rootless)
- Compatible OCI (Open Container Initiative)

**Le conflit :**
- Podman : `/run/podman/podman.sock`
- Docker : `/var/run/docker.sock`
- Si les deux installés → confusion

## Placement

Section ajoutée dans `content/chapitres/dev-env.adoc` après la section GitPod, car elle concerne l'installation locale de Docker (pas les environnements cloud comme GitPod qui ont Docker préconfiguré).

## Test Plan

- ✅ Build des slides : `make build`
- ✅ Vérification syntaxe AsciiDoc
- ✅ Speaker notes accessibles en mode présentation
- ✅ Solutions testées sur Ubuntu 25.04

## Benefits

- 🎓 Les étudiants avec Ubuntu 25.04 peuvent suivre le cours
- 📚 Explications pédagogiques sur l'évolution de l'écosystème conteneurs
- 🔧 Solutions pratiques testées
- 💡 Bonus : introduction à Podman comme alternative

---

Cette PR résout un problème pratique rencontré avec Ubuntu 25.04 tout en apportant du contenu pédagogique sur l'évolution de l'écosystème des conteneurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Installation locale de Docker” section after GitPod explaining Ubuntu 25.04+ defaulting to Podman and resulting Docker daemon connection errors.
  * Presents two solutions: a temporary per-session DOCKER_HOST workaround or the recommended removal of Podman and installation of Docker.
  * Includes guidance on making changes persistent, permission considerations, coursework recommendations, an optional Podman alias, and a comparison of approaches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->