### PR TITLE
ci: add concurrency group to prevent concurrent gh-pages deploy races

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -12,6 +12,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: deploy-${{ github.ref_name }}
+  cancel-in-progress: true
+
 env:
   REPOSITORY_URL: https://github.com/${{ github.repository }}
   PRESENTATION_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ github.ref_name }}

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -67,6 +67,9 @@ jobs:
     needs: [build-slides]
     # Only run deploy when pushing code on a branch of the repository
     if: github.event_name == 'push'
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     steps:
     - name: 'Download dist/ Artefacts'
       uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

- Adds a `concurrency` group (`deploy-${{ github.ref_name }}`) to the Slides Workflow
- `cancel-in-progress: true` cancels stale runs when a newer push arrives on the same branch
- Fixes the race condition seen in [run 24232350718](https://github.com/gounthar/cours-devops-docker/actions/runs/24232350718/job/70748951425) where two concurrent deploys both cloned `gh-pages` and the second push was rejected with `fetch first`

## Root cause

When two PRs were merged in quick succession (#348, #349), two deploy jobs ran in parallel. Both cloned the `gh-pages` branch at the same snapshot, built commits on top, and raced to push. The loser was rejected:

```
! [rejected] gh-pages -> gh-pages (fetch first)
error: failed to push some refs
```

## Pre-PR Review

**Reviewers**: CodeRabbit, Gemini (automated pre-review)

### Consensus
Clean — no issues flagged by multiple reviewers.

### Acknowledged
- **MINOR (Gemini)**: `cancel-in-progress: true` could cancel a deploy mid-flight. For `peaceiris/actions-gh-pages` this is safe — the git push is the last atomic step; an interrupted run before the push leaves gh-pages unchanged.

## Test plan

- [ ] Trigger two pushes in quick succession on a branch — verify second run is cancelled, not failed
- [ ] Verify the surviving run deploys successfully to gh-pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* **Enhanced deployment workflow** - Configured concurrent deployment management to automatically cancel redundant deployment runs, ensuring only the latest deployment executes per branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->