### PR TITLE
feat(slides): display last build date on title slide and PDF

### DIFF
--- a/content/index.adoc
+++ b/content/index.adoc
@@ -12,6 +12,7 @@ image::qrcode.png["QRCode to this presentation",height=150]
 * Version PDF de la présentation : link:slides.pdf[{pdf_icon} Cliquez ici,window="_blank"]
 * Contenu sous licence link:https://creativecommons.org/licenses/by/4.0/[Creative Commons Attribution 4.0 International License,window="_blank"]
 * Code source de la présentation: link:{repositoryUrl}[{github_icon} {repositoryUrl},window="_blank"]
+* Mis à jour le : {buildDate}
 
 [background-color="MediumBlue"]
 [.dark.background]

--- a/content/index.adoc
+++ b/content/index.adoc
@@ -12,7 +12,7 @@ image::qrcode.png["QRCode to this presentation",height=150]
 * Version PDF de la présentation : link:slides.pdf[{pdf_icon} Cliquez ici,window="_blank"]
 * Contenu sous licence link:https://creativecommons.org/licenses/by/4.0/[Creative Commons Attribution 4.0 International License,window="_blank"]
 * Code source de la présentation: link:{repositoryUrl}[{github_icon} {repositoryUrl},window="_blank"]
-* Mis à jour le : {buildDate}
+* Mis à jour le{nbsp}: {buildDate}
 
 [background-color="MediumBlue"]
 [.dark.background]

--- a/gulp/gulpfile.js
+++ b/gulp/gulpfile.js
@@ -93,6 +93,7 @@ function html(cb) {
                 'revealjsdir': 'node_modules/reveal.js@',
                 'presentationUrl': process.env.PRESENTATION_URL,
                 'repositoryUrl': process.env.REPOSITORY_URL,
+                'buildDate': new Date().toLocaleDateString('fr-FR', {year: 'numeric', month: 'long', day: 'numeric'}),
             },
             to_dir: current_config.buildDir,
         }

--- a/gulp/gulpfile.js
+++ b/gulp/gulpfile.js
@@ -93,7 +93,7 @@ function html(cb) {
                 'revealjsdir': 'node_modules/reveal.js@',
                 'presentationUrl': process.env.PRESENTATION_URL,
                 'repositoryUrl': process.env.REPOSITORY_URL,
-                'buildDate': new Date().toLocaleDateString('fr-FR', {year: 'numeric', month: 'long', day: 'numeric'}),
+                'buildDate': new Intl.DateTimeFormat('fr-FR', {year: 'numeric', month: 'long', day: 'numeric', timeZone: process.env.BUILD_TIMEZONE || 'Europe/Paris'}).format(new Date()),
             },
             to_dir: current_config.buildDir,
         }


### PR DESCRIPTION
## Summary

- Adds a `buildDate` attribute in `gulp/gulpfile.js` — computed at build time using `new Date().toLocaleDateString('fr-FR', ...)` (e.g. "10 avril 2026")
- Renders it on the title slide in `content/index.adoc` as `* Mis à jour le : {buildDate}`
- The PDF (`slides.pdf`) is generated from the rendered HTML via decktape, so the date appears there automatically with no additional changes

## How it works

```
gulpfile.js  →  buildDate attribute  →  Asciidoctor  →  index.html  →  decktape  →  slides.pdf
```

The date is computed at container build time, so every CI run stamps the output with the actual publish date.

## Test plan

- [ ] Run `make build` locally and verify the title slide shows the current date in French
- [ ] Run `make pdf` and verify the first page of `slides.pdf` shows the date
- [ ] Check that `index-examen.adoc` builds are unaffected (date only added to `index.adoc`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Presentations now show a "Mis à jour le" label displaying the build date, formatted in French and reflecting the build timezone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->