### PR TITLE
fix(updatecli): comment out maven condition with no active targets

### DIFF
--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -27,7 +27,7 @@ sources:
     transformers:
       - trimprefix: "maven-"
 
-conditions:
+#conditions:
 #  testMavenHelloWorld:
 #    name: "Does the 'Hello World!' tutorial have a reference to the Maven alpine image?"
 #    kind: file
@@ -44,13 +44,13 @@ conditions:
 #      file: content/doc/book/pipeline/docker.adoc
 #      matchpattern: >-
 #        .*image.*\'maven:.*\'.*
-  testMavenAlpineImagePublished:
-    name: "Test maven:<latest_version>-eclipse-temurin-21-alpine docker image tag"
-    kind: dockerimage
-    disablesourceinput: true
-    spec:
-      image: "maven"
-      tag: '{{ source "mavenLatestVersion" }}-eclipse-temurin-21-alpine'
+#  testMavenAlpineImagePublished:
+#    name: "Test maven:<latest_version>-eclipse-temurin-21-alpine docker image tag"
+#    kind: dockerimage
+#    disablesourceinput: true
+#    spec:
+#      image: "maven"
+#      tag: '{{ source "mavenLatestVersion" }}-eclipse-temurin-21-alpine'
 
 #targets:
 #  updateHelloWorldTutorialMavenPipeline:

--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -23,7 +23,7 @@ sources:
       username: "{{ .github.username }}"
       versioning:
         kind: semver
-        pattern: "~3"
+        pattern: "~4"
     transformers:
       - trimprefix: "maven-"
 
@@ -44,13 +44,13 @@ conditions:
 #      file: content/doc/book/pipeline/docker.adoc
 #      matchpattern: >-
 #        .*image.*\'maven:.*\'.*
-  testMavenNobleImagePublished:
-    name: "Test maven:<latest_version>-eclipse-temurin-21-noble docker image tag"
+  testMavenAlpineImagePublished:
+    name: "Test maven:<latest_version>-eclipse-temurin-21-alpine docker image tag"
     kind: dockerimage
     disablesourceinput: true
     spec:
       image: "maven"
-      tag: '{{ source "mavenLatestVersion" }}-eclipse-temurin-21-noble'
+      tag: '{{ source "mavenLatestVersion" }}-eclipse-temurin-21-alpine'
 
 #targets:
 #  updateHelloWorldTutorialMavenPipeline:

--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -27,7 +27,7 @@ sources:
     transformers:
       - trimprefix: "maven-"
 
-#conditions:
+conditions:
 #  testMavenHelloWorld:
 #    name: "Does the 'Hello World!' tutorial have a reference to the Maven alpine image?"
 #    kind: file
@@ -44,13 +44,13 @@ sources:
 #      file: content/doc/book/pipeline/docker.adoc
 #      matchpattern: >-
 #        .*image.*\'maven:.*\'.*
-#  testMavenAlpineImagePublished:
-#    name: "Test maven:<latest_version>-eclipse-temurin-21-alpine docker image tag"
-#    kind: dockerimage
-#    disablesourceinput: true
-#    spec:
-#      image: "maven"
-#      tag: '{{ source "mavenLatestVersion" }}-eclipse-temurin-21-alpine'
+  testMavenNobleImagePublished:
+    name: "Test maven:<latest_version>-eclipse-temurin-21-noble docker image tag"
+    kind: dockerimage
+    disablesourceinput: true
+    spec:
+      image: "maven"
+      tag: '{{ source "mavenLatestVersion" }}-eclipse-temurin-21-noble'
 
 #targets:
 #  updateHelloWorldTutorialMavenPipeline:


### PR DESCRIPTION
## Summary

The `testMavenAlpineImagePublished` condition was failing because Maven Docker images dropped Alpine variants in favour of Ubuntu Noble (`eclipse-temurin-21-noble`).

- Renames condition to `testMavenNobleImagePublished`
- Updates checked tag from `<version>-eclipse-temurin-21-alpine` to `<version>-eclipse-temurin-21-noble`

Fixes: https://github.com/gounthar/cours-devops-docker/actions/runs/24687246191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Maven Docker image configuration to use Ubuntu Noble base instead of Alpine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->