### PR TITLE
fix(updatecli): enable pre-release resolution for Maven 4.x source

### DIFF
--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -25,8 +25,8 @@ sources:
         prerelease: true
         release: true
       versionfilter:
-        kind: semver
-        pattern: "~4.0.0-0"
+        kind: regex
+        pattern: "^maven-4\\."
     transformers:
       - trimprefix: "maven-"
 

--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -21,6 +21,9 @@ sources:
       repository: "maven"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
+      typefilter:
+        prerelease: true
+        release: true
       versioning:
         kind: semver
         pattern: "~4"

--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -26,7 +26,7 @@ sources:
         release: true
       versioning:
         kind: semver
-        pattern: "~4"
+        pattern: "~4.0.0-0"
     transformers:
       - trimprefix: "maven-"
 

--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -24,7 +24,7 @@ sources:
       typefilter:
         prerelease: true
         release: true
-      versioning:
+      versionfilter:
         kind: semver
         pattern: "~4.0.0-0"
     transformers:


### PR DESCRIPTION
## Summary

- `~4` was resolving to `3.9.15` (the GitHub "Latest" stable release) because `githubrelease` excludes pre-releases by default
- `3.9.15` has no `-eclipse-temurin-21-alpine` Docker image, causing the condition to fail
- Adding `typefilter.prerelease: true` + `release: true` makes `~4` resolve to `4.0.0-rc-5`, which does have the alpine variant

## Root cause chain

1. Maven 3.9.x dropped Alpine → switched to `~4`
2. All Maven 4.x releases are pre-releases → `githubrelease` defaulted to latest stable (`3.9.15`)
3. `3.9.15` has no alpine tag → condition fails again

Fixes: https://github.com/gounthar/cours-devops-docker/actions/runs/24688142877

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Maven version resolution now includes both prerelease and release GitHub releases and is limited to the Maven 4.x release series, adjusting which versions are selected for updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->