### PR TITLE
fix(updatecli): fix asciidoctor version regex and correct invalid tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ pdf:
 	@$(call compose_up, --exit-code-from=pdf pdf)
 
 # Asciidoctor Docker image version - kept updated via updatecli
-ASCIIDOCTOR_IMAGE ?= asciidoctor/docker-asciidoctor:1.106.0.0
+ASCIIDOCTOR_IMAGE ?= asciidoctor/docker-asciidoctor:1.106.0
 
 exam-pdf:
 	@echo "Generating detailed exam PDF with LaTeX-style formatting..."

--- a/updatecli/updatecli.d/asciidoctor-updates.yaml
+++ b/updatecli/updatecli.d/asciidoctor-updates.yaml
@@ -32,7 +32,7 @@ targets:
     scmid: default
     spec:
       file: "Makefile"
-      matchpattern: 'ASCIIDOCTOR_IMAGE \?= asciidoctor/docker-asciidoctor:\d+\.\d+'
+      matchpattern: 'ASCIIDOCTOR_IMAGE \?= asciidoctor/docker-asciidoctor:[\d.]+'
       replacepattern: 'ASCIIDOCTOR_IMAGE ?= asciidoctor/docker-asciidoctor:{{ source "asciidoctor" }}'
 
 actions:

--- a/updatecli/updatecli.d/asciidoctor-updates.yaml
+++ b/updatecli/updatecli.d/asciidoctor-updates.yaml
@@ -32,7 +32,7 @@ targets:
     scmid: default
     spec:
       file: "Makefile"
-      matchpattern: 'ASCIIDOCTOR_IMAGE \?= asciidoctor/docker-asciidoctor:[\d.]+'
+      matchpattern: 'ASCIIDOCTOR_IMAGE \?= asciidoctor/docker-asciidoctor:[\w.-]+'
       replacepattern: 'ASCIIDOCTOR_IMAGE ?= asciidoctor/docker-asciidoctor:{{ source "asciidoctor" }}'
 
 actions:


### PR DESCRIPTION
## Summary

- The `matchpattern` regex `\d+\.\d+` in `updatecli/updatecli.d/asciidoctor-updates.yaml` only matched the first two version components (e.g. `1.106`), leaving any trailing segments (`.0.0`) untouched after substitution. Each updatecli run therefore appended version digits: `1.106.0` → `1.106.0.0` → `1.106.0.0.0`.
- Fixed the regex to `[\d.]+` so it greedily matches the full version string before substitution.
- Corrected the Makefile tag from the non-existent `1.106.0.0` back to the real `1.106.0` tag (verified against Docker Hub).

Closes #370

## Test plan

- [ ] Verify `asciidoctor/docker-asciidoctor:1.106.0` exists on Docker Hub (it does)
- [ ] Confirm the next updatecli run produces a clean replacement (no version suffix accumulation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Asciidoctor Docker image version for PDF generation
  * Enhanced automated update detection to match a wider range of Docker image tag formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->