### PR TITLE
fix(updatecli): exclude Maven release candidates from version filter

### DIFF
--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -22,11 +22,14 @@ sources:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       typefilter:
-        prerelease: true
+        prerelease: false
         release: true
       versionfilter:
         kind: regex
-        pattern: "^maven-3\\."
+        # Only final 3.x releases: apache/maven publishes release candidates
+        # (e.g. maven-3.10.0-rc-1) without flagging them as prereleases, and
+        # Docker Hub has no matching maven:<rc>-eclipse-temurin-21-alpine tag.
+        pattern: "^maven-3\\.[0-9]+\\.[0-9]+$"
     transformers:
       - trimprefix: "maven-"
 


### PR DESCRIPTION
## What

Anchors the Maven version filter to final three-part releases and stops accepting prereleases:

```diff
-        prerelease: true
+        prerelease: false
-        pattern: "^maven-3\\."
+        pattern: "^maven-3\\.[0-9]+\\.[0-9]+$"
```

## Why

The `updatecli` job has been failing on `main`:

```
✔ GitHub release version "maven-3.10.0-rc-1" found matching pattern "^maven-3\." of kind "regex"
✗ GET https://index.docker.io/v2/library/maven/manifests/3.10.0-rc-1-eclipse-temurin-21-alpine:
  MANIFEST_UNKNOWN: manifest unknown
ERROR: command failed: 2 pipeline(s) failed during execution
```

The previous pattern was broadened to `^maven-3\.` to keep Maven 4.x out. The gap is that
`apache/maven` publishes release candidates *without* marking them as GitHub prereleases —
`maven-3.10.0-rc-1` comes back with `prerelease=false` — so neither the type filter nor the
regex screened it out. Docker Hub has no matching `-eclipse-temurin-21-alpine` tag for an RC,
so the `testMavenAlpineImagePublished` condition errored and the job exited 1.

Requiring three numeric components excludes any `-rc-N`, `-alpha`, or `-beta` suffix. Setting
`prerelease: false` is belt-and-braces — it does nothing for this specific tag, but there is no
reason to pull prereleases into a docs-version bump.

## Verification

- New pattern's first match against the live release list: `maven-3.9.16`
- `maven:3.9.16-eclipse-temurin-21-alpine` on Docker Hub returns HTTP 200, so the condition passes
- `yamllint` reports nothing new (the remaining long-line warnings are pre-existing, all inside
  the commented-out target and action blocks)

## Note, not addressed here

The WAR pipeline in the same run is not a failure. Its `⚠` is dry-run reporting a pending change,
and `An action of kind "github/pullrequest" is expected.` is informational. The
`ERROR: ✗ 2 pipeline(s) failed` line is a miscount — the "showing reports failed" error gets added
to the tally. The run summary itself says `Failed: 1`.

Separately: every target and action in `maven.yaml` is commented out, so this pipeline can only
either fail or do nothing. Worth deciding whether to restore the targets or drop the file, but
that is a bigger question than unbreaking `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Maven release detection now excludes prerelease versions.
  * Only complete Maven 3.x.y versions are selected for updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->